### PR TITLE
* initial experimental support for kamon-agent + kamon 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 /* =========================================================================================
- * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -16,16 +16,16 @@
 val kamonCore         = "io.kamon"    %% "kamon-core"                   % "1.0.0-alpha1-05732d8693910248338744fa587bc4bc38ffb1ed"
 val scalazConcurrent  = "org.scalaz"  %% "scalaz-concurrent"            % "7.2.8"
 
-//kamon agent
-val agentScala        = "io.kamon"    %% "agent-scala-extension"        % "0.0.2-experimental"
-val kamonAgent        = "io.kamon"    %  "kamon-agent"                  % "0.0.2-experimental"
+//kamon-agent
+val agentScala        = "io.kamon"    %% "agent-scala-extension"        % "0.0.3-experimental"
+val kamonAgent        = "io.kamon"    %  "kamon-agent"                  % "0.0.3-experimental"
 
 lazy val root = (project in file("."))
   .settings(name := "kamon-scala")
   .settings(aspectJSettings: _*)
   .enablePlugins(JavaAgent)
   .settings(javaAgents += "org.aspectj" % "aspectjweaver" % "1.8.10"  % "compile;test")
-//  .settings(javaAgents += "io.kamon"    % "kamon-agent"   % "0.0.2-experimental"  % "test")
+//  .settings(javaAgents += "io.kamon"    % "kamon-agent"   % "0.0.3-experimental"  % "test")
   .settings(
       libraryDependencies ++=
         compileScope(kamonCore, agentScala) ++

--- a/build.sbt
+++ b/build.sbt
@@ -13,16 +13,23 @@
  * =========================================================================================
  */
 
-val kamonCore  = "io.kamon" %% "kamon-core" % "1.0.0-alpha1-05732d8693910248338744fa587bc4bc38ffb1ed"
-val scalazConcurrent  = "org.scalaz" %% "scalaz-concurrent" % "7.2.8"
+val kamonCore         = "io.kamon"    %% "kamon-core"                   % "1.0.0-alpha1-05732d8693910248338744fa587bc4bc38ffb1ed"
+val scalazConcurrent  = "org.scalaz"  %% "scalaz-concurrent"            % "7.2.8"
+
+//kamon agent
+val agentScala        = "io.kamon"    %% "agent-scala-extension"        % "0.0.2-experimental"
+val kamonAgent        = "io.kamon"    %  "kamon-agent"                  % "0.0.2-experimental"
 
 lazy val root = (project in file("."))
   .settings(name := "kamon-scala")
   .settings(aspectJSettings: _*)
+  .enablePlugins(JavaAgent)
+  .settings(javaAgents += "org.aspectj" % "aspectjweaver" % "1.8.10"  % "compile;test")
+//  .settings(javaAgents += "io.kamon"    % "kamon-agent"   % "0.0.2-experimental"  % "test")
   .settings(
       libraryDependencies ++=
-        compileScope(kamonCore) ++
-        providedScope(aspectJ) ++
+        compileScope(kamonCore, agentScala) ++
+        providedScope(aspectJ, kamonAgent) ++
         optionalScope(scalazConcurrent, twitterDependency("core").value) ++
         testScope(scalatest, logbackClassic))
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,4 @@
 lazy val root: Project = project.in(file(".")).dependsOn(latestSbtUmbrella)
 lazy val latestSbtUmbrella = uri("git://github.com/kamon-io/kamon-sbt-umbrella.git")
+
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.3")

--- a/src/main/java/kamon/instrumentation/scalaz/advisor/ParameterSubstitutionAdvisor.java
+++ b/src/main/java/kamon/instrumentation/scalaz/advisor/ParameterSubstitutionAdvisor.java
@@ -1,0 +1,36 @@
+package kamon.instrumentation.scalaz.advisor;
+
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+
+import kamon.agent.libs.net.bytebuddy.asm.Advice.Argument;
+import kamon.agent.libs.net.bytebuddy.asm.Advice.OnMethodEnter;
+import kamon.instrumentation.executor.ContinuationAwareExecutorService;
+
+import java.util.concurrent.ExecutorService;
+
+
+/**
+ * Advisor for scalaz.concurrent.Future$::apply
+ */
+public class ParameterSubstitutionAdvisor {
+
+    @OnMethodEnter
+    public static void enter(@Argument(value = 1, readOnly = false) ExecutorService es) {
+        es =  new ContinuationAwareExecutorService(es);
+    }
+}

--- a/src/main/java/kamon/instrumentation/twitter/advisor/ParameterSubstitutionAdvisor.java
+++ b/src/main/java/kamon/instrumentation/twitter/advisor/ParameterSubstitutionAdvisor.java
@@ -1,0 +1,36 @@
+package kamon.instrumentation.twitter.advisor;
+
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+
+import kamon.agent.libs.net.bytebuddy.asm.Advice.Argument;
+import kamon.agent.libs.net.bytebuddy.asm.Advice.OnMethodEnter;
+import kamon.instrumentation.executor.ContinuationAwareExecutorService;
+
+import java.util.concurrent.ExecutorService;
+
+
+/**
+ * Advisor for com.twitter.util.FuturePool$::apply
+ */
+public class ParameterSubstitutionAdvisor {
+
+    @OnMethodEnter
+    public static void enter(@Argument(value = 0, readOnly = false) ExecutorService es) {
+        es =  new ContinuationAwareExecutorService(es);
+    }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,6 +4,24 @@
 
 kamon {
 
+  agent {
+
+    show-banner = false
+    debug-mode = false
+
+    modules {
+      futures {
+        name = "Scala Futures Intrumentation Module."
+        stoppable = false
+        instrumentations = ["kamon.instrumentation.scala.FutureInstrumentation",
+                            "kamon.instrumentation.scalaz.FutureInstrumentation",
+                            "kamon.instrumentation.twitter.FutureInstrumentation"]
+
+        within = [ "scala.concurrent.*", "scalaz.concurrent.*", "com.twitter.util.*" ]
+      }
+    }
+  }
+
   modules {
     kamon-scala {
       requires-aspectj = yes

--- a/src/main/scala/kamon/instrumentation/executor/ContinuationAwareExecutorService.scala
+++ b/src/main/scala/kamon/instrumentation/executor/ContinuationAwareExecutorService.scala
@@ -47,14 +47,14 @@ class ContinuationAwareExecutorService(underlying: ExecutorService) extends Exec
     underlying.invokeAny(wrapCallables(tasks), timeout, unit)
   }
 
-  private def wrapRunnable(r: Runnable): TraceContextAwareRunnable = r match {
-    case runnable: TraceContextAwareRunnable ⇒ runnable
-    case _                                   ⇒ new TraceContextAwareRunnable(r)
+  private def wrapRunnable(r: Runnable): ContinuationAwareRunnable = r match {
+    case runnable: ContinuationAwareRunnable ⇒ runnable
+    case _                                   ⇒ new ContinuationAwareRunnable(r)
   }
 
-  private def wrapCallable[T](r: Callable[T]): TraceContextAwareCallable[T] = r match {
-    case callable: TraceContextAwareCallable[T] ⇒ callable
-    case _                                      ⇒ new TraceContextAwareCallable[T](r)
+  private def wrapCallable[T](r: Callable[T]): ContinuationAwareCallable[T] = r match {
+    case callable: ContinuationAwareCallable[T] ⇒ callable
+    case _                                      ⇒ new ContinuationAwareCallable[T](r)
   }
 
   private def wrapCallables[T](tasks: util.Collection[_ <: Callable[T]]) = {
@@ -64,7 +64,7 @@ class ContinuationAwareExecutorService(underlying: ExecutorService) extends Exec
   }
 }
 
-class TraceContextAwareRunnable(r: Runnable) extends Runnable {
+class ContinuationAwareRunnable(r: Runnable) extends Runnable {
   val continuation = Kamon.activeSpan().capture()
 
   override def run(): Unit = {
@@ -74,7 +74,7 @@ class TraceContextAwareRunnable(r: Runnable) extends Runnable {
   }
 }
 
-class TraceContextAwareCallable[A](c: Callable[A]) extends HasContinuation with Callable[A] {
+class ContinuationAwareCallable[A](c: Callable[A]) extends HasContinuation with Callable[A] {
   val continuation = Kamon.activeSpan().capture()
 
   override def call(): A = {

--- a/src/main/scala/kamon/instrumentation/executor/ContinuationAwareExecutorService.scala
+++ b/src/main/scala/kamon/instrumentation/executor/ContinuationAwareExecutorService.scala
@@ -1,0 +1,85 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.instrumentation.executor
+
+import java.util
+import java.util.concurrent.{Callable, ExecutorService, Future, TimeUnit}
+
+import kamon.Kamon
+import kamon.util.HasContinuation
+
+
+class ContinuationAwareExecutorService(underlying: ExecutorService) extends ExecutorService {
+  override def isShutdown: Boolean = underlying.isShutdown
+  override def shutdown(): Unit = underlying.shutdown()
+  override def shutdownNow(): util.List[Runnable] = underlying.shutdownNow()
+
+  override def isTerminated: Boolean = underlying.isTerminated
+  override def awaitTermination(timeout: Long, unit: TimeUnit): Boolean = underlying.awaitTermination(timeout, unit)
+
+  override def submit[A](task: Callable[A]): Future[A] = underlying.submit(wrapCallable(task))
+  override def submit[A](task: Runnable, result: A): Future[A] = underlying.submit(wrapRunnable(task), result)
+  override def submit(task: Runnable): Future[_] = underlying.submit(wrapRunnable(task))
+
+  override def execute(command: Runnable): Unit = underlying.execute(wrapRunnable(command))
+
+  override def invokeAll[A](tasks: util.Collection[_ <: Callable[A]]): util.List[Future[A]] = underlying.invokeAll(wrapCallables(tasks))
+  override def invokeAll[A](tasks: util.Collection[_ <: Callable[A]], timeout: Long, unit: TimeUnit): util.List[Future[A]] = {
+    underlying.invokeAll(wrapCallables(tasks), timeout, unit)
+  }
+
+  override def invokeAny[A](tasks: util.Collection[_ <: Callable[A]]): A = underlying.invokeAny(wrapCallables(tasks))
+  override def invokeAny[A](tasks: util.Collection[_ <: Callable[A]], timeout: Long, unit: TimeUnit): A = {
+    underlying.invokeAny(wrapCallables(tasks), timeout, unit)
+  }
+
+  private def wrapRunnable(r: Runnable): TraceContextAwareRunnable = r match {
+    case runnable: TraceContextAwareRunnable ⇒ runnable
+    case _                                   ⇒ new TraceContextAwareRunnable(r)
+  }
+
+  private def wrapCallable[T](r: Callable[T]): TraceContextAwareCallable[T] = r match {
+    case callable: TraceContextAwareCallable[T] ⇒ callable
+    case _                                      ⇒ new TraceContextAwareCallable[T](r)
+  }
+
+  private def wrapCallables[T](tasks: util.Collection[_ <: Callable[T]]) = {
+    import scala.collection.JavaConverters._
+
+    tasks.asScala.map(wrapCallable).asInstanceOf[util.Collection[_ <: Callable[T]]]
+  }
+}
+
+class TraceContextAwareRunnable(r: Runnable) extends Runnable {
+  val continuation = Kamon.activeSpan().capture()
+
+  override def run(): Unit = {
+    Kamon.withContinuation(continuation) {
+      r.run()
+    }
+  }
+}
+
+class TraceContextAwareCallable[A](c: Callable[A]) extends HasContinuation with Callable[A] {
+  val continuation = Kamon.activeSpan().capture()
+
+  override def call(): A = {
+    Kamon.withContinuation(continuation) {
+      c.call()
+    }
+  }
+}

--- a/src/main/scala/kamon/instrumentation/mixin/HasContinuationMixin.scala
+++ b/src/main/scala/kamon/instrumentation/mixin/HasContinuationMixin.scala
@@ -1,0 +1,33 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.instrumentation.mixin
+
+import io.opentracing.ActiveSpan.Continuation
+import kamon.Kamon
+import kamon.agent.api.instrumentation.Initializer
+import kamon.util.HasContinuation
+
+/**
+  * Mixin for scala.concurrent.impl.CallbackRunnable
+  * Mixin for scala.concurrent.impl.Future$PromiseCompletingRunnable
+  */
+class HasContinuationMixin extends HasContinuation {
+  var continuation:Continuation = _
+
+  @Initializer
+  def init(): Unit = this.continuation = Kamon.activeSpan().capture()
+}

--- a/src/main/scala/kamon/instrumentation/scala/FutureInstrumentation.scala
+++ b/src/main/scala/kamon/instrumentation/scala/FutureInstrumentation.scala
@@ -1,0 +1,46 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.instrumentation.scala
+
+import kamon.agent.scala.KamonInstrumentation
+import kamon.instrumentation.scala.advisor.RunMethodAdvisor
+import kamon.instrumentation.mixin.HasContinuationMixin
+
+class FutureInstrumentation extends KamonInstrumentation {
+
+  /**
+    * Instrument:
+    *
+    * scala.concurrent.impl.CallbackRunnable::run
+    * scala.concurrent.impl.Future$PromiseCompletingRunnable::run
+    *
+    * Mix:
+    *
+    * scala.concurrent.impl.CallbackRunnable with kamon.trace.TraceContextAware
+    * scala.concurrent.impl.Future$PromiseCompletingRunnable with kamon.trace.TraceContextAware
+    *
+    */
+
+  val RunMethod = named("run")
+
+  forTargetType("scala.concurrent.impl.CallbackRunnable" or "scala.concurrent.impl.Future$PromiseCompletingRunnable") { builder ⇒
+    builder
+      .withMixin(classOf[HasContinuationMixin])
+      .withAdvisorFor(RunMethod, classOf[RunMethodAdvisor])
+      .build()
+  }
+}

--- a/src/main/scala/kamon/instrumentation/scala/advisor/RunMethodAdvisor.scala
+++ b/src/main/scala/kamon/instrumentation/scala/advisor/RunMethodAdvisor.scala
@@ -1,0 +1,37 @@
+
+/*
+ * =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.instrumentation.scala.advisor
+
+import io.opentracing.ActiveSpan
+import kamon.agent.libs.net.bytebuddy.asm.Advice.{Enter, OnMethodEnter, OnMethodExit, This}
+import kamon.util.HasContinuation
+
+/**
+  * Advisor for scala.concurrent.impl.CallbackRunnable::run
+  * Advisor for scala.concurrent.impl.Future$PromiseCompletingRunnable::run
+  */
+class RunMethodAdvisor
+object RunMethodAdvisor {
+  @OnMethodEnter
+  def onEnter(@This runnable: HasContinuation): ActiveSpan =
+    runnable.continuation.activate()
+
+  @OnMethodExit(onThrowable = classOf[Throwable])
+  def onExit(@Enter activeSpan:ActiveSpan): Unit =
+    activeSpan.deactivate()
+}

--- a/src/main/scala/kamon/instrumentation/scalaz/FutureInstrumentation.scala
+++ b/src/main/scala/kamon/instrumentation/scalaz/FutureInstrumentation.scala
@@ -1,0 +1,36 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.instrumentation.scalaz
+
+import kamon.agent.scala.KamonInstrumentation
+import kamon.instrumentation.scalaz.advisor.ParameterSubstitutionAdvisor
+
+class FutureInstrumentation extends KamonInstrumentation {
+  /**
+    * Instrument:
+    *
+    * scalaz.concurrent.Future::apply
+    *
+    */
+  val ApplyMethod = named("apply")
+
+  forTargetType("scalaz.concurrent.Future$") { builder ⇒
+    builder
+      .withAdvisorFor(ApplyMethod, classOf[ParameterSubstitutionAdvisor])
+      .build()
+  }
+}

--- a/src/main/scala/kamon/instrumentation/twitter/FutureInstrumentation.scala
+++ b/src/main/scala/kamon/instrumentation/twitter/FutureInstrumentation.scala
@@ -1,0 +1,35 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.instrumentation.twitter
+
+import kamon.agent.scala.KamonInstrumentation
+import kamon.instrumentation.twitter.advisor.ParameterSubstitutionAdvisor
+
+class FutureInstrumentation extends KamonInstrumentation {
+  /**
+    * Instrument:
+    *
+    * com.twitter.util.FuturePool::apply
+    */
+  val ApplyMethod = named("apply")
+
+  forTargetType("com.twitter.util.FuturePool$") { builder ⇒
+    builder
+      .withAdvisorFor(ApplyMethod, classOf[ParameterSubstitutionAdvisor])
+      .build()
+  }
+}

--- a/src/test/scala/kamon/twitter/instrumentation/FutureInstrumentationSpec.scala
+++ b/src/test/scala/kamon/twitter/instrumentation/FutureInstrumentationSpec.scala
@@ -17,11 +17,12 @@ package kamon.twitter.instrumentation
 
 import java.util.concurrent.Executors
 
-import org.scalatest.{Matchers, OptionValues, WordSpec}
-import org.scalatest.concurrent.{PatienceConfiguration, ScalaFutures}
 import com.twitter.util.{Await, FuturePool}
 import kamon.Kamon
 import kamon.Kamon.buildSpan
+import org.scalatest.concurrent.{PatienceConfiguration, ScalaFutures}
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+
 
 class FutureInstrumentationSpec extends WordSpec with Matchers with ScalaFutures with PatienceConfiguration with OptionValues {
   implicit val execContext = Executors.newCachedThreadPool()


### PR DESCRIPTION
* Initial experimental support for kamon-agent + kamon 1.0, running by default the tests with `AspectJ`.
* In order to run the test with `kamon-agent` we need comment the line [27] and uncomment the line [28],
* +test

@ivantopo enjoy!!

[27]:https://github.com/dpsoft/kamon-scala/blob/kamon-agent/build.sbt#L27
[28]:https://github.com/dpsoft/kamon-scala/blob/kamon-agent/build.sbt#L28